### PR TITLE
SSL links for Twitter, GitHub in header; Remove type on script tags

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -31,8 +31,8 @@
             {{ knp_menu_render('phpDocumentorWebsiteBundle:Builder:mainMenu') }}
 
             <ul class="nav nav-pills">
-                <li><a href="http://github.com/phpDocumentor/phpDocumentor2" title="Github &middot; Fork me"><i class="icon-github-alt"></i></a></li>
-                <li><a href="http://twitter.com/phpdocumentor" title="Twitter &middot; @phpDocumentor"><i class="icon-twitter"></i></a></li>
+                <li><a href="https://github.com/phpDocumentor/phpDocumentor2" title="Github &middot; Fork me"><i class="icon-github-alt"></i></a></li>
+                <li><a href="https://twitter.com/phpdocumentor" title="Twitter &middot; @phpDocumentor"><i class="icon-twitter"></i></a></li>
                 <li><a href="contact" title="IRC &middot; #phpdocumentor at Freenode"><i class="icon-comments"></i></a></li>
             </ul>
         </nav>
@@ -137,13 +137,13 @@
     </footer>
 
     <!--[if lt IE 9]>
-    <script src="{{ asset('bundles/phpdocumentorwebsite/js/html5shiv.js') }}" type="text/javascript"></script>
+    <script src="{{ asset('bundles/phpdocumentorwebsite/js/html5shiv.js') }}"></script>
     <![endif]-->
-    <script src="{{ asset('js/jquery-1.8.0.min.js') }}" type="text/javascript"></script>
-    <script src="{{ asset('js/bootstrap-2.2.2.min.js') }}" type="text/javascript"></script>
-    <script src="{{ asset('js/modernizr-2.6.2.min.js') }}" type="text/javascript"></script>
-    <script src="{{ asset('bundles/phpdocumentorwebsite/js/jquery.elastislide.js') }}" type="text/javascript"></script>
-    <script src="{{ asset('bundles/phpdocumentorwebsite/js/jquery.prism.js') }}" type="text/javascript"></script>
+    <script src="{{ asset('js/jquery-1.8.0.min.js') }}"></script>
+    <script src="{{ asset('js/bootstrap-2.2.2.min.js') }}"></script>
+    <script src="{{ asset('js/modernizr-2.6.2.min.js') }}"></script>
+    <script src="{{ asset('bundles/phpdocumentorwebsite/js/jquery.elastislide.js') }}"></script>
+    <script src="{{ asset('bundles/phpdocumentorwebsite/js/jquery.prism.js') }}"></script>
     {% block javascripts %}{% endblock %}
     <script>
         $('.content-overview nav a').click(function (e) {


### PR DESCRIPTION
Updates Twitter and GitHub links to use SSL version as that is what users will be redirected to when clicked.

Removes extraneous `type="text/javascript"` from SCRIPT tags as no longer needed.
