### PR TITLE
Run composer install from Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,6 @@ web/app_dev.php
 .*
 build.xml
 docker-compose.yml
-composer.*
 LICENSE
 README.md
 Vagrantfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,6 @@ Make sure you add the following to your /etc/hosts file
     127.0.0.1 dev.phpdoc.org
 
 Then, from the project root run 
-
-    composer install
     
     docker-compose up -d
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ RUN apt-get update \
     && apt-get install -yq libicu-dev libicu52 libcurl4-gnutls-dev libgmp3-dev libgmp-dev php5-mysql \
     && ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/local/include/ \
     && docker-php-ext-install -j$(nproc) intl gmp curl sockets bcmath pdo_mysql \
-    && a2enmod rewrite
-
-RUN curl -sS https://getcomposer.org/installer | php \
+    && a2enmod rewrite \
+    && curl -sS https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer
 
 WORKDIR /opt/webapp
@@ -15,4 +14,6 @@ WORKDIR /opt/webapp
 ADD docker/vhost.conf /etc/apache2/sites-available/000-default.conf
 ADD . /opt/webapp
 
-RUN cd /opt/webapp && composer install
+RUN cd /opt/webapp \
+    && composer install \
+    && rm /usr/local/bin/composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,12 @@ RUN apt-get update \
     && docker-php-ext-install -j$(nproc) intl gmp curl sockets bcmath pdo_mysql \
     && a2enmod rewrite
 
+RUN curl -sS https://getcomposer.org/installer | php \
+    && mv composer.phar /usr/local/bin/composer
+
 WORKDIR /opt/webapp
 
 ADD docker/vhost.conf /etc/apache2/sites-available/000-default.conf
 ADD . /opt/webapp
+
+RUN cd /opt/webapp && composer install


### PR DESCRIPTION
The Dockerfile now includes composer and installs the dependencies for phpdoc.org.
